### PR TITLE
Feature/plugin umbenennung

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,40 @@
-# Grünerator Gutenberg Addon
+# Grünerator WordPress
 
-Ein WordPress-Plugin, das spezielle Gutenberg-Blöcke für grüne Websites bereitstellt.
+Ein WordPress-Plugin, das Dir hilft, professionelle Kandidatenseiten für grüne Kandidierende mit Gutenberg-Blöcken zu erstellen. Entwickelt speziell für das [Sunflower WordPress-Theme](https://github.com/codeispoetry/sunflower).
 
 ## 🚀 Features
 
-- Spezielle Gutenberg-Blöcke
+- Spezielle Gutenberg-Blöcke für Kandidatenseiten
+  - Kandidaten-Profil Block
+  - Themen-Block
+  - Wahlkreis-Block
+  - Termine-Block
 - Setup-Assistent für schnelle Einrichtung
 - Social Media Integration
-- Vorgefertigte Block-Patterns
-- Anpassbare Styles
+- Vorgefertigte Block-Patterns für Kandidatenprofile
 
 ## 📋 Anforderungen
 
 - WordPress 5.8 oder höher
 - PHP 7.4 oder höher
-- Node.js und npm für Entwicklung
+- Node.js 14+ und npm für Entwicklung
+- [Sunflower WordPress-Theme](https://github.com/codeispoetry/sunflower) installiert und aktiviert
 
 ## 🔧 Installation
 
-1. Laden Sie das Plugin herunter
-2. Entpacken Sie es in Ihr `/wp-content/plugins/` Verzeichnis
-3. Aktivieren Sie das Plugin in WordPress
-4. Gehen Sie zu "Grünerator" im Admin-Menü
+1. Stelle sicher, dass das Sunflower-Theme installiert und aktiviert ist
+2. Lade das Plugin herunter
+3. Entpacke es in Dein `/wp-content/plugins/` Verzeichnis
+4. Aktiviere das Plugin in WordPress
+5. Gehe zu "Grünerator" im Admin-Menü
 
 ## 💻 Entwicklung
 
 ```bash
+# Repository klonen
+git clone https://github.com/netzbegruenung/gruenerator-wordpress.git
+cd gruenerator-wordpress
+
 # Abhängigkeiten installieren
 npm install
 
@@ -36,10 +45,66 @@ npm run start
 npm run build
 ```
 
+### Theme-Abhängigkeit
+
+Dieses Plugin erweitert das Sunflower-Theme um zusätzliche Gutenberg-Blöcke und Funktionen. Die Blöcke sind speziell für das Design und die Funktionen des Themes optimiert. Ohne das Sunflower-Theme werden die Blöcke nicht korrekt dargestellt.
+
+### Branch-Struktur
+
+Wir nutzen eine vereinfachte Git-Flow Struktur:
+
+- `main`: Produktions-Code (stabil)
+- `develop`: Entwicklungs-Branch (aktuell)
+- `feature/*`: Für neue Features (z.B. `feature/kandidaten-profil`)
+- `bugfix/*`: Für Fehlerbehebungen (z.B. `bugfix/mobile-ansicht`)
+
+### Commit-Konventionen
+
+Wir nutzen [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+typ(bereich): beschreibung
+
+- Detaillierte Beschreibung (optional)
+- Weitere Details (optional)
+```
+
+Typen:
+- `feat:` Neue Features
+- `fix:` Bugfixes
+- `docs:` Dokumentationsänderungen
+- `style:` Code-Formatierung
+- `refactor:` Code-Verbesserungen
+- `test:` Test-bezogene Änderungen
+
+Beispiel:
+```bash
+git commit -m "feat(profil): Füge Lebenslauf-Block hinzu"
+```
+
+### Pull Requests
+
+1. Fork das Repository
+2. Erstelle einen Feature-Branch (`git checkout -b feature/NeuesFeature`)
+3. Committe Deine Änderungen (`git commit -m 'feat: Füge neues Feature hinzu'`)
+4. Push in den Branch (`git push origin feature/NeuesFeature`)
+5. Öffne einen Pull Request
+
 ## 📝 Lizenz
 
 GPL v2 oder später - siehe [LICENSE](LICENSE) Datei
 
 ## 🤝 Mitwirken
 
-Beiträge, Issues und Feature-Requests sind willkommen! 
+Deine Beiträge sind willkommen! Bitte lies Dir unsere [Contribution Guidelines](CONTRIBUTING.md) durch.
+
+### Code-Qualität
+
+- Halte Dich an die [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/)
+- Schreibe Tests für neue Features
+- Dokumentiere Deinen Code
+- Führe `npm run lint` vor jedem Commit aus
+
+## 🔗 Verwandte Projekte
+
+- [Sunflower WordPress-Theme](https://github.com/codeispoetry/sunflower) - Das Basis-Theme für dieses Plugin 

--- a/gruenerator.php
+++ b/gruenerator.php
@@ -5,19 +5,21 @@
  * @version 1.0.0
  * 
  * @wordpress-plugin
- * Plugin Name: Gruenerator Gutenberg Addon
- * Description: Fügt spezielle Gutenberg-Blöcke hinzu, die nur mit einem spezifischen Theme funktionieren. Erstellt eine Seite mit vorgefertigten Blöcken auf Knopfdruck.
+ * Plugin Name: Grünerator WordPress
+ * Description: Erstelle professionelle Kandidatenseiten für grüne Kandidierende mit speziellen Gutenberg-Blöcken. Dieses Plugin wurde speziell für das Sunflower WordPress-Theme entwickelt und erfordert dessen Installation.
  * Version: 1.0.0
- * Author: Dein Name
+ * Author: Moritz Wächter
  * License: GPL v2 oder später
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: gruenerator
  * Domain Path: /languages
  * Requires at least: 5.8
  * Requires PHP: 7.4
+ * Requires Plugins: 
+ * Requires Themes: sunflower
  *
- * Dieses Plugin ist ein Gutenberg-Addon speziell für grüne Websites.
- * Es erweitert WordPress um spezielle Blöcke und Funktionen.
+ * Dieses Plugin ist eine Erweiterung für das Sunflower-Theme und fügt spezielle
+ * Gutenberg-Blöcke und Funktionen hinzu, die auf das Theme abgestimmt sind.
  *
  * @since 1.0.0
  */

--- a/package.json
+++ b/package.json
@@ -1,16 +1,25 @@
 {
-  "name": "sunflower-gutenberg-addon",
+  "name": "gruenerator-wordpress",
   "version": "1.0.0",
+  "description": "Ein WordPress-Plugin für professionelle Kandidatenseiten der Grünen",
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "wp-scripts build",
     "start": "wp-scripts start"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
+  "keywords": [
+    "wordpress",
+    "gutenberg",
+    "gruene",
+    "politik",
+    "kandidaten"
+  ],
+  "author": {
+    "name": "Moritz Wächter",
+    "url": "https://github.com/netzbegruenung"
+  },
+  "license": "GPL-2.0-or-later",
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-class-properties": "^7.25.4",


### PR DESCRIPTION
# Ändere Plugin-Name zu Grünerator WordPress

## Änderungen

- Ändert den Plugin-Namen von 'Sunflower Gutenberg Addon' zu 'Grünerator WordPress'
- Aktualisiert die Plugin-Beschreibung mit Theme-Abhängigkeit
- Setzt Autor auf Moritz Wächter
- Verbessert die Dokumentation in README.md

## Abhängigkeiten
- Erfordert das Sunflower WordPress-Theme
