### PR TITLE
refactor: Reorganize settings page into proper class structure

### DIFF
--- a/admin/gruenerator-settings.php
+++ b/admin/gruenerator-settings.php
@@ -5,9 +5,9 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Zeigt Admin-Benachrichtigungen an
+ * Callback-Funktion für die Einstellungsseite
  */
-function gruenerator_settings_admin_notices() {
-    settings_errors('gruenerator_messages');
-}
-add_action('admin_notices', 'gruenerator_settings_admin_notices'); 
+function gruenerator_settings_page() {
+    $settings = Gruenerator_Settings::get_instance();
+    $settings->render_settings_page();
+} 

--- a/gruenerator.php
+++ b/gruenerator.php
@@ -35,6 +35,7 @@ require_once GRUENERATOR_PATH . 'includes/class-gruenerator-customizer.php';
 require_once GRUENERATOR_PATH . 'includes/class-gruenerator-blocks.php';
 require_once GRUENERATOR_PATH . 'includes/class-gruenerator-meta-fields.php';
 require_once GRUENERATOR_PATH . 'includes/class-gruenerator-social-media.php';
+require_once GRUENERATOR_PATH . 'includes/class-gruenerator-settings.php';
 
 // Lade Admin-spezifische Dateien
 require_once GRUENERATOR_PATH . 'admin/gruenerator-setup-wizard.php';

--- a/includes/class-gruenerator-settings.php
+++ b/includes/class-gruenerator-settings.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Klasse für die Verwaltung der Plugin-Einstellungen
+ *
+ * @package Gruenerator
+ * @since 1.0.0
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Die Hauptklasse für die Plugin-Einstellungen
+ */
+class Gruenerator_Settings {
+
+    /**
+     * Die einzige Instanz dieser Klasse
+     *
+     * @since 1.0.0
+     * @access private
+     * @var Gruenerator_Settings
+     */
+    private static $instance = null;
+
+    /**
+     * Konstruktor
+     *
+     * @since 1.0.0
+     * @access private
+     */
+    private function __construct() {
+        add_action('admin_post_gruenerator_reset_settings', array($this, 'handle_reset_settings'));
+        add_action('admin_post_gruenerator_set_frontpage', array($this, 'handle_set_frontpage'));
+        add_action('admin_post_gruenerator_reset_frontpage', array($this, 'handle_reset_frontpage'));
+        add_action('admin_notices', array($this, 'show_admin_notices'));
+    }
+
+    /**
+     * Gibt die einzige Instanz dieser Klasse zurück
+     *
+     * @since 1.0.0
+     * @access public
+     *
+     * @return Gruenerator_Settings Die einzige Instanz dieser Klasse
+     */
+    public static function get_instance() {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Rendert die Einstellungsseite
+     *
+     * @since 1.0.0
+     * @access public
+     */
+    public function render_settings_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die('Unzureichende Berechtigungen');
+        }
+
+        // Hole die aktuelle Startseiten-ID
+        $front_page_id = get_option('page_on_front');
+        $landing_page_id = get_option('gruenerator_landing_page_id');
+        $is_landing_page_front = ($front_page_id == $landing_page_id);
+        ?>
+        <div class="wrap">
+            <h1>Grünerator Einstellungen</h1>
+
+            <div class="gruenerator-settings-section">
+                <h2>Startseite</h2>
+                <div class="gruenerator-settings-card">
+                    <h3>Startseiten-Einstellung</h3>
+                    <?php if ($landing_page_id): ?>
+                        <?php if ($is_landing_page_front): ?>
+                            <p>Deine Grünerator Landing Page ist aktuell als Startseite festgelegt.</p>
+                            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('Möchtest du die Startseiten-Einstellung wirklich zurücksetzen? Die Standard-Blogansicht wird dann als Startseite verwendet.');">
+                                <?php wp_nonce_field('gruenerator_reset_frontpage_nonce'); ?>
+                                <input type="hidden" name="action" value="gruenerator_reset_frontpage">
+                                <input type="submit" class="button button-secondary" value="Startseiten-Einstellung zurücksetzen">
+                            </form>
+                        <?php else: ?>
+                            <p>Die Grünerator Landing Page ist aktuell nicht als Startseite festgelegt.</p>
+                            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                                <?php wp_nonce_field('gruenerator_set_frontpage_nonce'); ?>
+                                <input type="hidden" name="action" value="gruenerator_set_frontpage">
+                                <input type="submit" class="button button-primary" value="Als Startseite festlegen">
+                            </form>
+                        <?php endif; ?>
+                    <?php else: ?>
+                        <p>Es wurde noch keine Landing Page erstellt. Bitte durchlaufe zuerst den Setup-Assistenten.</p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="gruenerator-settings-section">
+                <h2>Zurücksetzen</h2>
+                <p>Hier kannst du alle Einstellungen des Grünerators auf die Standardwerte zurücksetzen.</p>
+                
+                <div class="gruenerator-settings-card">
+                    <h3>Alle Einstellungen zurücksetzen</h3>
+                    <p>Diese Aktion setzt alle Einstellungen des Grünerators auf die Standardwerte zurück. Dies betrifft:</p>
+                    <ul>
+                        <li>Design-Einstellungen</li>
+                        <li>Social Media Verknüpfungen</li>
+                        <li>Hero-Bereich</li>
+                        <li>Über mich</li>
+                        <li>Hauptthema</li>
+                        <li>Politische Schwerpunkte</li>
+                        <li>Aktionsbereich</li>
+                        <li>Kontaktbereich</li>
+                    </ul>
+                    <p class="description" style="color: #d63638;">Achtung: Diese Aktion kann nicht rückgängig gemacht werden!</p>
+                    
+                    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('Bist du sicher, dass du alle Einstellungen zurücksetzen möchtest? Diese Aktion kann nicht rückgängig gemacht werden!');">
+                        <?php wp_nonce_field('gruenerator_reset_settings_nonce'); ?>
+                        <input type="hidden" name="action" value="gruenerator_reset_settings">
+                        <input type="submit" class="button button-secondary" value="Alle Einstellungen zurücksetzen">
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <style>
+            .gruenerator-settings-section {
+                margin: 2rem 0;
+                max-width: 800px;
+            }
+            .gruenerator-settings-card {
+                background: white;
+                border: 1px solid #ccd0d4;
+                border-radius: 4px;
+                padding: 1.5rem;
+                margin: 1rem 0;
+            }
+            .gruenerator-settings-card h3 {
+                margin-top: 0;
+            }
+            .gruenerator-settings-card ul {
+                list-style: disc;
+                margin-left: 1.5rem;
+            }
+            .gruenerator-settings-card .button {
+                margin-top: 1rem;
+            }
+        </style>
+        <?php
+    }
+
+    /**
+     * Verarbeitet das Zurücksetzen aller Einstellungen
+     *
+     * @since 1.0.0
+     * @access public
+     */
+    public function handle_reset_settings() {
+        if (!current_user_can('manage_options')) {
+            wp_die('Unzureichende Berechtigungen');
+        }
+
+        if (!isset($_POST['_wpnonce']) || !wp_verify_nonce($_POST['_wpnonce'], 'gruenerator_reset_settings_nonce')) {
+            wp_die('Sicherheitsüberprüfung fehlgeschlagen');
+        }
+
+        // Liste aller Optionen, die zurückgesetzt werden sollen
+        $options_to_reset = array(
+            'gruenerator_use_css',
+            'gruenerator_social_facebook',
+            'gruenerator_social_twitter',
+            'gruenerator_social_instagram',
+            'gruenerator_hero_image',
+            'gruenerator_hero_heading',
+            'gruenerator_hero_text',
+            'gruenerator_about_me_title',
+            'gruenerator_about_me_content',
+            'gruenerator_hero_image_block_image',
+            'gruenerator_hero_image_title',
+            'gruenerator_hero_image_subtitle',
+        );
+
+        // Füge die Themen-Optionen hinzu
+        for ($i = 1; $i <= 3; $i++) {
+            $options_to_reset[] = 'gruenerator_theme_image_' . $i;
+            $options_to_reset[] = 'gruenerator_theme_title_' . $i;
+            $options_to_reset[] = 'gruenerator_theme_content_' . $i;
+        }
+
+        // Füge die Aktions-Optionen hinzu
+        for ($i = 1; $i <= 3; $i++) {
+            $options_to_reset[] = 'gruenerator_action_image_' . $i;
+            $options_to_reset[] = 'gruenerator_action_text_' . $i;
+            $options_to_reset[] = 'gruenerator_action_link_' . $i;
+        }
+
+        // Füge die Kontaktformular-Optionen hinzu
+        $options_to_reset[] = 'gruenerator_contact_form_title';
+        $options_to_reset[] = 'gruenerator_contact_form_image';
+        $options_to_reset[] = 'gruenerator_contact_form_email';
+
+        // Lösche alle Optionen
+        foreach ($options_to_reset as $option) {
+            delete_option($option);
+        }
+
+        // Setze eine Erfolgsmeldung
+        add_settings_error(
+            'gruenerator_messages',
+            'gruenerator_reset_success',
+            'Alle Einstellungen wurden erfolgreich zurückgesetzt.',
+            'success'
+        );
+
+        // Leite zurück zur Einstellungsseite
+        wp_safe_redirect(add_query_arg(
+            array('page' => 'gruenerator-settings', 'settings-updated' => 'true'),
+            admin_url('admin.php')
+        ));
+        exit;
+    }
+
+    /**
+     * Setzt die Landing Page als Startseite
+     *
+     * @since 1.0.0
+     * @access public
+     */
+    public function handle_set_frontpage() {
+        if (!current_user_can('manage_options')) {
+            wp_die('Unzureichende Berechtigungen');
+        }
+
+        if (!isset($_POST['_wpnonce']) || !wp_verify_nonce($_POST['_wpnonce'], 'gruenerator_set_frontpage_nonce')) {
+            wp_die('Sicherheitsüberprüfung fehlgeschlagen');
+        }
+
+        $landing_page_id = get_option('gruenerator_landing_page_id');
+        if ($landing_page_id) {
+            update_option('show_on_front', 'page');
+            update_option('page_on_front', $landing_page_id);
+        }
+
+        wp_safe_redirect(add_query_arg(
+            array('page' => 'gruenerator-settings', 'settings-updated' => 'true'),
+            admin_url('admin.php')
+        ));
+        exit;
+    }
+
+    /**
+     * Setzt die Startseite zurück auf die Standard-Blogansicht
+     *
+     * @since 1.0.0
+     * @access public
+     */
+    public function handle_reset_frontpage() {
+        if (!current_user_can('manage_options')) {
+            wp_die('Unzureichende Berechtigungen');
+        }
+
+        if (!isset($_POST['_wpnonce']) || !wp_verify_nonce($_POST['_wpnonce'], 'gruenerator_reset_frontpage_nonce')) {
+            wp_die('Sicherheitsüberprüfung fehlgeschlagen');
+        }
+
+        update_option('show_on_front', 'posts');
+        delete_option('page_on_front');
+
+        wp_safe_redirect(add_query_arg(
+            array('page' => 'gruenerator-settings', 'settings-updated' => 'true'),
+            admin_url('admin.php')
+        ));
+        exit;
+    }
+
+    /**
+     * Zeigt Admin-Benachrichtigungen an
+     *
+     * @since 1.0.0
+     * @access public
+     */
+    public function show_admin_notices() {
+        settings_errors('gruenerator_messages');
+    }
+} 

--- a/includes/setup-wizard-steps.php
+++ b/includes/setup-wizard-steps.php
@@ -470,6 +470,16 @@ function gruenerator_final_step() {
                 <li>Alle Einstellungen können später über das Grünerator-Dashboard angepasst werden</li>
             </ul>
         </div>
+
+        <table class="form-table">
+            <tr>
+                <th scope="row"><label for="gruenerator_set_as_frontpage">Als Startseite festlegen</label></th>
+                <td>
+                    <input type="checkbox" id="gruenerator_set_as_frontpage" name="gruenerator_set_as_frontpage" value="1">
+                    <p class="description">Aktiviere diese Option, um die erstellte Landingpage als Startseite deiner Website festzulegen.</p>
+                </td>
+            </tr>
+        </table>
     </div>
     <?php
 }
@@ -512,138 +522,3 @@ function gruenerator_setup_complete_page() {
 }
 
 add_action('admin_post_gruenerator_process_setup', 'gruenerator_process_setup');
-
-/**
- * Einstellungsseite des Grünerators
- */
-function gruenerator_settings_page() {
-    if (!current_user_can('manage_options')) {
-        wp_die('Unzureichende Berechtigungen');
-    }
-    ?>
-    <div class="wrap">
-        <h1>Grünerator Einstellungen</h1>
-        
-        <div class="gruenerator-settings-section">
-            <h2>Zurücksetzen</h2>
-            <p>Hier kannst du alle Einstellungen des Grünerators auf die Standardwerte zurücksetzen.</p>
-            
-            <div class="gruenerator-settings-card">
-                <h3>Alle Einstellungen zurücksetzen</h3>
-                <p>Diese Aktion setzt alle Einstellungen des Grünerators auf die Standardwerte zurück. Dies betrifft:</p>
-                <ul>
-                    <li>Design-Einstellungen</li>
-                    <li>Social Media Verknüpfungen</li>
-                    <li>Hero-Bereich</li>
-                    <li>Über mich</li>
-                    <li>Hauptthema</li>
-                    <li>Politische Schwerpunkte</li>
-                    <li>Aktionsbereich</li>
-                    <li>Kontaktbereich</li>
-                </ul>
-                <p class="description" style="color: #d63638;">Achtung: Diese Aktion kann nicht rückgängig gemacht werden!</p>
-                
-                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('Bist du sicher, dass du alle Einstellungen zurücksetzen möchtest? Diese Aktion kann nicht rückgängig gemacht werden!');">
-                    <?php wp_nonce_field('gruenerator_reset_settings_nonce'); ?>
-                    <input type="hidden" name="action" value="gruenerator_reset_settings">
-                    <input type="submit" class="button button-secondary" value="Alle Einstellungen zurücksetzen">
-                </form>
-            </div>
-        </div>
-        
-        <style>
-            .gruenerator-settings-section {
-                margin: 2rem 0;
-                max-width: 800px;
-            }
-            .gruenerator-settings-card {
-                background: white;
-                border: 1px solid #ccd0d4;
-                border-radius: 4px;
-                padding: 1.5rem;
-                margin: 1rem 0;
-            }
-            .gruenerator-settings-card h3 {
-                margin-top: 0;
-            }
-            .gruenerator-settings-card ul {
-                list-style: disc;
-                margin-left: 1.5rem;
-            }
-            .gruenerator-settings-card .button {
-                margin-top: 1rem;
-            }
-        </style>
-    </div>
-    <?php
-}
-
-add_action('admin_post_gruenerator_reset_settings', 'gruenerator_reset_settings');
-
-/**
- * Verarbeitet das Zurücksetzen der Einstellungen
- */
-function gruenerator_reset_settings() {
-    if (!current_user_can('manage_options')) {
-        wp_die('Unzureichende Berechtigungen');
-    }
-
-    if (!isset($_POST['_wpnonce']) || !wp_verify_nonce($_POST['_wpnonce'], 'gruenerator_reset_settings_nonce')) {
-        wp_die('Sicherheitsüberprüfung fehlgeschlagen');
-    }
-
-    // Liste aller Optionen, die zurückgesetzt werden sollen
-    $options_to_reset = array(
-        'gruenerator_use_css',
-        'gruenerator_social_facebook',
-        'gruenerator_social_twitter',
-        'gruenerator_social_instagram',
-        'gruenerator_hero_image',
-        'gruenerator_hero_heading',
-        'gruenerator_hero_text',
-        'gruenerator_about_me_title',
-        'gruenerator_about_me_content',
-        'gruenerator_hero_image_block_image',
-        'gruenerator_hero_image_title',
-        'gruenerator_hero_image_subtitle',
-    );
-
-    // Füge die Themen-Optionen hinzu
-    for ($i = 1; $i <= 3; $i++) {
-        $options_to_reset[] = 'gruenerator_theme_image_' . $i;
-        $options_to_reset[] = 'gruenerator_theme_title_' . $i;
-        $options_to_reset[] = 'gruenerator_theme_content_' . $i;
-    }
-
-    // Füge die Aktions-Optionen hinzu
-    for ($i = 1; $i <= 3; $i++) {
-        $options_to_reset[] = 'gruenerator_action_image_' . $i;
-        $options_to_reset[] = 'gruenerator_action_text_' . $i;
-        $options_to_reset[] = 'gruenerator_action_link_' . $i;
-    }
-
-    // Füge die Kontaktformular-Optionen hinzu
-    $options_to_reset[] = 'gruenerator_contact_form_title';
-    $options_to_reset[] = 'gruenerator_contact_form_image';
-    $options_to_reset[] = 'gruenerator_contact_form_email';
-
-    // Lösche alle Optionen
-    foreach ($options_to_reset as $option) {
-        delete_option($option);
-    }
-
-    // Setze eine Erfolgsmeldung
-    add_settings_error(
-        'gruenerator_messages',
-        'gruenerator_reset_success',
-        'Alle Einstellungen wurden erfolgreich zurückgesetzt.',
-        'success'
-    );
-
-    // Leite zurück zur Einstellungsseite
-    wp_safe_redirect(add_query_arg(
-        array('page' => 'gruenerator-settings', 'settings-updated' => 'true'),
-        admin_url('admin.php')
-    ));
-    exit;
-}


### PR DESCRIPTION
- Move settings page functionality into new Gruenerator_Settings class

- Add homepage settings to settings page

- Remove old settings code from wizard

- Follow WordPress coding standards with proper documentation

- Implement singleton pattern for settings management